### PR TITLE
Scrutinizer: fix phpcs command

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,7 +7,7 @@ tools:
         test_command: ./vendor/bin/phpunit
     php_code_sniffer:
         enabled: true
-        test_command: ./vendor/bin/phpcs
+        command: ./vendor/bin/phpcs
         config:
             standard: PSR2
         filter:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,8 @@
+build:
+    environment:
+        php:
+            version: 7.0
+
 before_commands:
     - "composer update --prefer-source"
 
@@ -7,7 +12,7 @@ tools:
         test_command: ./vendor/bin/phpunit
     php_code_sniffer:
         enabled: true
-        command: ./vendor/bin/phpcs
+        command: composer update && vendor/bin/phpcs
         config:
             standard: PSR2
         filter:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,6 +7,7 @@ tools:
         test_command: ./vendor/bin/phpunit
     php_code_sniffer:
         enabled: true
+        test_command: ./vendor/bin/phpcs
         config:
             standard: PSR2
         filter:

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     },
     "require-dev": {
         "phpunit/phpunit":              "^5.0",
-        "zendframework/zend-diactoros": "^1.1"
+        "zendframework/zend-diactoros": "^1.1",
+        "squizlabs/php_codesniffer":    "^2.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Looks like Scrutinizer's version of phpcs is outdated.

I tried with phpcs 2.3.4 and timeoutes too on some Squiz sniff.

With version 2.5 all passes well. Probably it has bug fixed.

Ref https://github.com/Ocramius/PSR7Session/pull/37#issuecomment-164752245