### PR TITLE
Suggest sane default for cookie path

### DIFF
--- a/examples/index.php
+++ b/examples/index.php
@@ -43,7 +43,8 @@ $sessionMiddleware = new SessionMiddleware(
     'c9UA8QKLSmDEn4DhNeJIad/4JugZd/HvrjyKrS0jOes=', // verification key (important: change this to your own)
     SetCookie::create('an-example-cookie-name')
         ->withSecure(false) // false on purpose, unless you have https locally
-        ->withHttpOnly(true),
+        ->withHttpOnly(true)
+        ->withPath('/'),
     new Parser(),
     1200 // 20 minutes
 );


### PR DESCRIPTION
Browsers will start a new session for every uri without it ->withPath('/') 